### PR TITLE
Updating status of the DOORS Wiki

### DIFF
--- a/v2/experience-links.json
+++ b/v2/experience-links.json
@@ -1169,7 +1169,8 @@
         "type": "communityWiki",
         "url": "doors-game.fandom.com",
         "locale": "en",
-        "fromFandomInterwiki": true
+        "fromFandomInterwiki": true,
+        "isOfficialWiki": true
       }
     ]
   },


### PR DESCRIPTION
Hey there, I'm a [Bureaucrat](https://doors-game.fandom.com/wiki/DOORS_Wiki:Staff) of the [Official DOORS Wiki](https://doors-game.fandom.com/wiki/DOORS_Wiki), here to tell you that the wiki is indeed Official, we have both Developers in our Wiki Discord Server, both being Lightning_Splash, on the wiki: [LSplashYeet](https://doors-game.fandom.com/wiki/User:LSplashYeet) and Redibles, on the wiki: [RediblesQW](https://doors-game.fandom.com/wiki/User:RediblesQW).

Let me know if you have further questions.